### PR TITLE
fix vercel api configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,27 +1,15 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    },
-    {
-      "src": "api/**/*.js",
-      "use": "@vercel/node"
+  "buildCommand": "npm run vercel-build",
+  "outputDirectory": "dist",
+  "functions": {
+    "api/**/*": {
+      "runtime": "nodejs18.x"
     }
-  ],
-  "routes": [
-    {
-      "src": "/api/(.*)",
-      "dest": "/api/$1"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
+  },
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
   ],
   "env": {
     "NODE_ENV": "production"


### PR DESCRIPTION
## Summary
- simplify Vercel configuration and ensure API functions use Node 18 runtime
- add rewrites for API and SPA routing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npx vercel@latest build --yes` *(fails: The specified token is not valid. Use `vercel login` to generate a new token.)*

------
https://chatgpt.com/codex/tasks/task_b_68a0079ba01c832bb56db7b9027b2c5b